### PR TITLE
Naive spline implementation

### DIFF
--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -158,6 +158,23 @@ fn setup(mut commands: Commands) {
         Occluder2d::rectangle(10., 10.),
         Transform::from_translation(vec3(-109., 210., 0.)),
     ));
+
+    commands.spawn((
+        Occluder2d::spline(
+            CubicCardinalSpline::new_catmull_rom(vec![
+                vec2(0., 0.),
+                vec2(100., 0.),
+                vec2(120., 150.),
+                vec2(54., 120.),
+                vec2(0., 170.),
+            ])
+            .to_curve()
+            .unwrap(),
+            10,
+        )
+        .unwrap(),
+        Transform::from_translation(vec3(-410., -200., 0.)),
+    ));
 }
 
 fn move_light(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //! - [Polylines](crate::occluders::Occluder2d::polyline).
 //! - [Polygons](crate::occluders::Occluder2d::polygon) (concave and convex).
 //! - Round shapes such as [circles](crate::occluders::Occluder2d::circle), [capsules](crate::occluders::Occluder2d::capsule), [round rectangles](crate::occluders::Occluder2d::round_rectangle).
+//! - [Splines](crate::occluders::Occluder2d::spline) are sampled into [polylines](crate::occluders::Occluder2d::polyline).
 //!
 //! Occluders have an [opacity](crate::occluders::Occluder2d::opacity), ranging from transprent to fully opaque, and can cast [colored shadows](crate::occluders::Occluder2d::opacity).   
 //!

--- a/src/occluders.rs
+++ b/src/occluders.rs
@@ -134,6 +134,19 @@ impl Occluder2d {
             .and_then(|vertices| Some(Self::from_shape(Occluder2dShape::Polyline { vertices })))
     }
 
+    /// Construct a polyline occluder from the given spline.
+    ///
+    /// The spline is sampled and converted to a polyline, as such
+    /// having self-intersections can cause unexpected behavior.
+    /// The control points should be relative to the entity's translation.
+    ///
+    /// # Failure
+    /// This returns None if the provided spline contains no segments.
+    pub fn spline(spline: CubicCurve<Vec2>, samples_per_segment: usize) -> Option<Self> {
+        let samples = samples_per_segment * spline.segments().len();
+        Self::polyline(spline.iter_positions(samples).collect())
+    }
+
     /// Construct a rectangle occluder from width and height.
     pub fn rectangle(width: f32, height: f32) -> Self {
         Self::round_rectangle(width, height, 0.)


### PR DESCRIPTION
# Objective

Add spline support for `Occluder2d`.

# Solution

Naive implementation using polylines.

# Tests

Added spline example to [shapes examples](tests/shapes.rs).


Feel free to close this pr if you don't like stuff about it.